### PR TITLE
feat: パスワードリセット機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ end
 # ===== 開発環境専用 =====
 group :development do
   gem "web-console"                # ブラウザ上でのデバッグコンソール
+  gem "letter_opener_web", "~> 2.0"  # 開発環境でメールをブラウザで確認
 end
 
 # ===== テスト環境専用 =====

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,8 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
     concurrent-ruby (1.3.5)
     connection_pool (2.5.4)
     crass (1.0.6)
@@ -171,6 +173,17 @@ GEM
       activesupport (>= 7.0.0)
     json (2.13.2)
     language_server-protocol (3.17.0.5)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    letter_opener (1.10.0)
+      launchy (>= 2.2, < 4)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     lint_roller (1.1.0)
     logger (1.7.0)
     loofah (2.24.1)
@@ -414,6 +427,7 @@ DEPENDENCIES
   fog-aws
   importmap-rails
   jbuilder
+  letter_opener_web (~> 2.0)
   mini_magick
   pg (~> 1.1)
   propshaft

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,43 @@
-<h2>Change your password</h2>
+<!-- app/views/devise/passwords/edit.html.erb -->
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        新しいパスワードを設定
+      </h2>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "mt-8 space-y-6" }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
+      <%= f.hidden_field :reset_password_token %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <div class="rounded-md shadow-sm space-y-4">
+        <div>
+          <%= f.label :password, "新しいパスワード（6文字以上）", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.password_field :password, 
+              autofocus: true, 
+              autocomplete: "new-password",
+              placeholder: "新しいパスワード",
+              class: "mt-1 appearance-none rounded-md relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
+
+        <div>
+          <%= f.label :password_confirmation, "新しいパスワード（確認用）", class: "block text-sm font-medium text-gray-700" %>
+          <%= f.password_field :password_confirmation, 
+              autocomplete: "new-password",
+              placeholder: "新しいパスワード（確認用）",
+              class: "mt-1 appearance-none rounded-md relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm" %>
+        </div>
+      </div>
+
+      <div>
+        <%= f.submit "パスワードを変更", 
+            class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
+      </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
-  </div>
 
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
+    <div class="text-center">
+      <%= link_to "ログイン画面に戻る", new_user_session_path, class: "font-medium text-indigo-600 hover:text-indigo-500" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,16 +1,38 @@
-<h2>Forgot your password?</h2>
+<!-- app/views/devise/passwords/new.html.erb -->
+<div class="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+  <div class="max-w-md w-full space-y-8">
+    <div>
+      <h2 class="mt-6 text-center text-3xl font-extrabold text-gray-900">
+        パスワードをお忘れですか？
+      </h2>
+      <p class="mt-2 text-center text-sm text-gray-600">
+        登録されているメールアドレスを入力してください。<br>
+        パスワードリセット用のリンクをお送りします。
+      </p>
+    </div>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "mt-8 space-y-6" }) do |f| %>
+      <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
+      <div class="rounded-md shadow-sm -space-y-px">
+        <div>
+          <%= f.label :email, "メールアドレス", class: "sr-only" %>
+          <%= f.email_field :email, 
+              autofocus: true, 
+              autocomplete: "email",
+              placeholder: "メールアドレス",
+              class: "appearance-none rounded-md relative block w-full px-3 py-2 border border-gray-300 placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 focus:z-10 sm:text-sm" %>
+        </div>
+      </div>
+
+      <div>
+        <%= f.submit "パスワードリセットメールを送信", 
+            class: "group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 cursor-pointer" %>
+      </div>
+    <% end %>
+
+    <div class="text-center">
+      <%= link_to "ログイン画面に戻る", new_user_session_path, class: "font-medium text-indigo-600 hover:text-indigo-500" %>
+    </div>
   </div>
-
-  <div class="actions">
-    <%= f.submit "Send me reset password instructions" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -28,11 +28,13 @@ Rails.application.configure do
   # アップロードファイルはローカルに保存（config/storage.yml を参照）
   config.active_storage.service = :local
 
-  # メール送信失敗時にエラーを無視
-  config.action_mailer.raise_delivery_errors = false
+  # メール送信失敗時にエラーを表示する（開発中はエラーを把握するため true にする）
+  config.action_mailer.raise_delivery_errors = true
 
   # メール送信結果をキャッシュしない
   config.action_mailer.perform_caching = false
+  config.action_mailer.delivery_method = :letter_opener_web
+
 
   # 開発用メールリンクのホスト名とポート番号を指定
   config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
@@ -58,6 +60,4 @@ Rails.application.configure do
   # コントローラのbefore_actionで存在しないアクション指定があればエラー
   config.action_controller.raise_on_missing_callback_actions = true
 
-  # Devise用のメール設定
-  config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,11 @@
 Rails.application.routes.draw do
   devise_for :users
+
+  # 開発環境でメールをブラウザで確認できるようにする
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
+
   get "up" => "rails/health#show", as: :rails_health_check
 
   root "posts#index"


### PR DESCRIPTION
## 変更内容
パスワードリセット機能を実装しました。

## 実装内容
- letter_opener_webを導入（開発環境でメール確認用）
- Deviseのビューファイルをカスタマイズ
- パスワードリセット申請画面のデザイン調整
- 新パスワード設定画面のデザイン調整
- メール送信設定を追加

## 動作確認
- [x] パスワードリセット申請からメール送信まで動作確認済み
- [x] メール内リンクから新パスワード設定まで動作確認済み
- [x] 新しいパスワードでログイン成功

## 主要な変更ファイル
- Gemfile
- config/routes.rb
- config/environments/development.rb
- app/views/devise/passwords/new.html.erb
- app/views/devise/passwords/edit.html.erb