### PR TITLE
feat: ページネーション機能の実装とデザインカスタマイズ

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,8 @@ gem "bootsnap", require: false     # Rails起動高速化
 gem "carrierwave"                  # ファイルアップロード管理
 gem "fog-aws"                      # AWS S3との連携
 gem "mini_magick"                  # 画像リサイズ・変換処理
+gem "kaminari", "~> 1.2"           # ページネーション機能
+
 
 # ===== 開発・テスト環境専用 =====
 group :development, :test do
@@ -43,6 +45,9 @@ end
 group :development do
   gem "web-console"                # ブラウザ上でのデバッグコンソール
   gem "letter_opener_web", "~> 2.0"  # 開発環境でメールをブラウザで確認
+  gem "ruby-lsp", require: false          # LSP本体
+  gem "ruby-lsp-rails", require: false    # Rails向け拡張（ActiveRecordの推論が強くなる）
+
 end
 
 # ===== テスト環境専用 =====

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -172,6 +172,18 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     json (2.13.2)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.5)
     launchy (3.1.1)
       addressable (~> 2.8)
@@ -299,6 +311,8 @@ GEM
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
     rake (13.3.0)
+    rbs (3.9.5)
+      logger
     rdoc (6.14.2)
       erb
       psych (>= 4.0.0)
@@ -337,6 +351,12 @@ GEM
       rubocop (>= 1.72)
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
+    ruby-lsp (0.26.1)
+      language_server-protocol (~> 3.17.0)
+      prism (>= 1.2, < 2.0)
+      rbs (>= 3, < 5)
+    ruby-lsp-rails (0.4.8)
+      ruby-lsp (>= 0.26.0, < 0.27.0)
     ruby-progressbar (1.13.0)
     ruby-vips (2.2.5)
       ffi (~> 1.12)
@@ -427,6 +447,7 @@ DEPENDENCIES
   fog-aws
   importmap-rails
   jbuilder
+  kaminari (~> 1.2)
   letter_opener_web (~> 2.0)
   mini_magick
   pg (~> 1.1)
@@ -434,6 +455,8 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 7.2.2)
   rubocop-rails-omakase
+  ruby-lsp
+  ruby-lsp-rails
   selenium-webdriver
   solid_cable
   solid_cache

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -4,7 +4,7 @@ class PostsController < ApplicationController
   before_action :check_owner, only: [ :edit, :update, :destroy ]
 
   def index
-    @posts = Post.includes(:user, :achievements).recent
+    @posts = Post.includes(:user, :achievements).recent.page(params[:page]).per(20)
   end
 
   def show

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,2 @@
+<%# 最初のページへのリンク %>
+<%= link_to_unless current_page.first?, raw("« 最初"), url, class: "px-4 py-2 border-2 border-black bg-white hover:bg-gray-100 font-bold transition-colors" %>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,4 @@
+<%# ページ番号の省略記号 %>
+<span class="px-4 py-2 text-gray-400 font-bold">
+  ...
+</span>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,2 @@
+<%# 最後のページへのリンク %>
+<%= link_to_unless current_page.last?, raw("最後 »"), url, class: "px-4 py-2 border-2 border-black bg-white hover:bg-gray-100 font-bold transition-colors" %>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,2 @@
+<%# 次のページへのリンク %>
+<%= link_to_unless current_page.last?, raw("次へ →"), url, rel: 'next', class: "px-4 py-2 border-2 border-black bg-white hover:bg-gray-100 font-bold transition-colors" %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,8 @@
+<%# 各ページ番号のリンク %>
+<% if page.current? %>
+  <span class="px-4 py-2 border-2 border-black bg-black text-white font-bold">
+    <%= page %>
+  </span>
+<% else %>
+  <%= link_to page, url, class: "px-4 py-2 border-2 border-black bg-white hover:bg-gray-100 font-bold transition-colors", rel: page.rel %>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,16 @@
+<%# Kaminariページネーションの全体構造 %>
+<%= paginator.render do %>
+  <nav class="flex justify-center items-center gap-2" role="navigation" aria-label="ページネーション">
+    <%= first_page_tag unless current_page.first? %>
+    <%= prev_page_tag unless current_page.first? %>
+    <% each_page do |page| %>
+      <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+        <%= page_tag page %>
+      <% elsif !page.was_truncated? %>
+        <%= gap_tag %>
+      <% end %>
+    <% end %>
+    <%= next_page_tag unless current_page.last? %>
+    <%= last_page_tag unless current_page.last? %>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,2 @@
+<%# 前のページへのリンク %>
+<%= link_to_unless current_page.first?, raw("← 前へ"), url, rel: 'prev', class: "px-4 py-2 border-2 border-black bg-white hover:bg-gray-100 font-bold transition-colors" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -72,5 +72,8 @@
         <% end %>
       <% end %>
     </div>
+    <div class="flex justify-center mt-8">
+      <%= paginate @posts %>
+    </div>
   <% end %>
 </div>


### PR DESCRIPTION
## 変更内容
投稿一覧にページネーション機能を実装（1ページ20件表示）

## 実装内容
- kaminari gemを導入
- PostsController#indexにページネーション処理を追加
- app/views/kaminari/にカスタムビューを作成

## 動作確認
- [x] 20件ごとにページ分割される
- [x] ページ遷移が正常に動作

## 変更ファイル
- Gemfile
- app/controllers/posts_controller.rb
- app/views/posts/index.html.erb
- app/views/kaminari/_*.html.erb（7ファイル）