### PR TITLE
SMTP設定のhostキーをaddressに修正

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: "www.mitadake.com" }
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    host: "smtp.resend.com",
+    address: "smtp.resend.com",
     port: 465,
     user_name: "resend",
     password: ENV["RESEND_API_KEY"],  # Render.comの環境変数に設定


### PR DESCRIPTION
## 概要
パスワードリセットメールがlocalhostに接続しようとして失敗していた問題を修正。

## 変更内容
- `config/environments/production.rb`: `smtp_settings`の`host:`キーを正しい`address:`キーに変更

## 原因
Railsの`smtp_settings`では`host:`は無効なキーのため無視され、デフォルトの`localhost`が使用されていた。

## テスト方法
1. 本番環境でパスワードリセットメールを送信
2. `Errno::ECONNREFUSED`エラーが発生しないことを確認
3. リセットメールが届くことを確認